### PR TITLE
Add offline caching using IndexedDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ npm install
    `VITE_EXCEL_SHARE_LINK`.
 
 ### Modo offline
-Si no hay conexión a Internet, la aplicación puede mostrar los datos
-almacenados en caché localmente (última sincronización exitosa).
+La aplicación guarda la última lista de procesos en IndexedDB cada vez
+que se pulsa **Refrescar**. Si al intentar obtener el JSON ocurre un
+error de red, se cargan esos datos cacheados y se indica "offline" en la
+parte inferior de la pantalla junto con la fecha de la última
+sincronización.
 
 ## Deploy
 Puede desplegarse en servicios como Netlify o GitHub Pages. En ambos casos,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.3.0",
+        "idb-keyval": "^6.2.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "xlsx": "^0.18.5"
@@ -1435,6 +1436,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^11.3.0",
+    "idb-keyval": "^6.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "xlsx": "^0.18.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,41 +1,9 @@
 import React from 'react';
-import { useEffect, useState } from 'react';
-
-type Proceso = {
-  programa: string;
-  facultad: string;
-  rrc_raa: string;
-  procedimiento: string;
-  modalidad: string;
-  responsable: string;
-  estado: string;
-  observaciones: string;
-};
+import { useProcesos } from './hooks/useProcesos';
+import { LastSyncBanner } from './components/LastSyncBanner';
 
 export default function App() {
-  const [data, setData] = useState<Proceso[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const refresh = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const url = (import.meta.env.VITE_DATA_URL || '/procesos.json') + '?t=' + Date.now();
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(res.statusText);
-      const json: Proceso[] = await res.json();
-      setData(json);
-    } catch (e: any) {
-      setError(e.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    refresh();
-  }, []);
+  const { data, loading, error, lastSync, offline, refresh } = useProcesos();
 
   return (
     <div style={{ padding: 16, fontFamily: 'sans-serif' }}>
@@ -55,6 +23,7 @@ export default function App() {
           </li>
         ))}
       </ul>
+      <LastSyncBanner lastSync={lastSync} offline={offline} />
     </div>
   );
 }

--- a/src/components/LastSyncBanner.tsx
+++ b/src/components/LastSyncBanner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface Props {
+  lastSync: Date | null;
+  offline: boolean;
+}
+
+export function LastSyncBanner({ lastSync, offline }: Props) {
+  const text = lastSync
+    ? lastSync.toLocaleString('es-CO', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      })
+    : 'Nunca';
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        background: '#eee',
+        padding: '4px 8px',
+        fontSize: 12,
+        textAlign: 'center'
+      }}
+    >
+      Última actualización: {text} {offline && '(offline)'}
+    </div>
+  );
+}

--- a/src/hooks/useProcesos.ts
+++ b/src/hooks/useProcesos.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import { loadProcesos, saveProcesos, Proceso } from '../lib/db';
+
+export function useProcesos() {
+  const [data, setData] = useState<Proceso[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastSync, setLastSync] = useState<Date | null>(null);
+  const [offline, setOffline] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setOffline(false);
+    try {
+      const url = (import.meta.env.VITE_DATA_URL || '/procesos.json') + '?t=' + Date.now();
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(res.statusText);
+      const json: Proceso[] = await res.json();
+      const now = new Date();
+      setData(json);
+      setLastSync(now);
+      await saveProcesos(json, now);
+    } catch (e: any) {
+      setError(e.message);
+      const cache = await loadProcesos();
+      setData(cache.data);
+      setLastSync(cache.lastSync);
+      setOffline(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, error, lastSync, offline, refresh };
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,27 @@
+import { get, set } from 'idb-keyval';
+
+export type Proceso = {
+  programa: string;
+  facultad: string;
+  rrc_raa: string;
+  procedimiento: string;
+  modalidad: string;
+  responsable: string;
+  estado: string;
+  observaciones: string;
+};
+
+const KEY_PROCESOS = 'procesos';
+const KEY_LAST_SYNC = 'lastSync';
+
+export async function saveProcesos(data: Proceso[], date: Date) {
+  await Promise.all([set(KEY_PROCESOS, data), set(KEY_LAST_SYNC, date)]);
+}
+
+export async function loadProcesos(): Promise<{ data: Proceso[]; lastSync: Date | null }> {
+  const [data, last] = await Promise.all([
+    get<Proceso[]>(KEY_PROCESOS),
+    get<Date>(KEY_LAST_SYNC)
+  ]);
+  return { data: data || [], lastSync: last || null };
+}


### PR DESCRIPTION
## Summary
- persist downloaded data in IndexedDB
- add hook `useProcesos` to handle cache and refresh logic
- show last synchronization banner
- document the new offline cache behaviour
- include `idb-keyval` dependency

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68828c1b510c8327bbdbabc155cbcefe