### PR TITLE
Add combined filters and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ error de red, se cargan esos datos cacheados y se indica "offline" en la
 parte inferior de la pantalla junto con la fecha de la última
 sincronización.
 
+### Filtros y búsqueda
+La barra de filtros permite filtrar por **Responsable**, **Estado** y un
+campo de texto libre que busca coincidencias en *programa* u
+*observaciones*. Puede combinarse de la siguiente forma:
+
+- Seleccionar solo un Estado muestra todos los responsables con ese
+  estado.
+- Seleccionar solo un Responsable filtra por esa persona.
+- Al escribir texto se filtra adicionalmente por coincidencia.
+El botón **Limpiar filtros** restablece todo a `(Todos)`.
+
 ## Deploy
 Puede desplegarse en servicios como Netlify o GitHub Pages. En ambos casos,
 defina las variables del `.env` en el panel del servicio y ejecute el script

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,28 +1,72 @@
-import React from 'react';
-import { useProcesos } from './hooks/useProcesos';
-import { LastSyncBanner } from './components/LastSyncBanner';
+import React, { useState, useMemo } from "react";
+import { useProcesos } from "./hooks/useProcesos";
+import { LastSyncBanner } from "./components/LastSyncBanner";
+import { Filters } from "./components/Filters";
+import { ProcessList } from "./components/ProcessList";
+import { ProcessModal } from "./components/ProcessModal";
+import type { Proceso } from "./types";
 
 export default function App() {
   const { data, loading, error, lastSync, offline, refresh } = useProcesos();
+  const [responsable, setResponsable] = useState("");
+  const [estado, setEstado] = useState("");
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<Proceso | null>(null);
+
+  const responsables = useMemo(
+    () => Array.from(new Set(data.map((p) => p.responsable))).sort(),
+    [data],
+  );
+  const estados = useMemo(
+    () => Array.from(new Set(data.map((p) => p.estado))).sort(),
+    [data],
+  );
+
+  const filtered = useMemo(() => {
+    const text = search.toLowerCase();
+    return data.filter((p) => {
+      const matchResp = !responsable || p.responsable === responsable;
+      const matchEstado = !estado || p.estado === estado;
+      const matchText =
+        !text ||
+        p.programa.toLowerCase().includes(text) ||
+        p.observaciones.toLowerCase().includes(text);
+      return matchResp && matchEstado && matchText;
+    });
+  }, [data, responsable, estado, search]);
+
+  const clearFilters = () => {
+    setResponsable("");
+    setEstado("");
+    setSearch("");
+  };
 
   return (
-    <div style={{ padding: 16, fontFamily: 'sans-serif' }}>
+    <div style={{ padding: 16, fontFamily: "sans-serif" }}>
       <h1>Seguimiento Procesos</h1>
 
       <button onClick={refresh} disabled={loading} style={{ marginBottom: 12 }}>
-        {loading ? 'Actualizando…' : 'Refrescar'}
+        {loading ? "Actualizando…" : "Refrescar"}
       </button>
 
-      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
-      <p>Total registros: {data.length}</p>
+      {error && <p style={{ color: "red" }}>Error: {error}</p>}
 
-      <ul style={{ maxHeight: '60vh', overflowY: 'auto' }}>
-        {data.map((p, i) => (
-          <li key={i}>
-            <b>{p.programa}</b> — {p.estado} / {p.procedimiento} — {p.responsable}
-          </li>
-        ))}
-      </ul>
+      <Filters
+        responsables={responsables}
+        estados={estados}
+        selectedResponsable={responsable}
+        selectedEstado={estado}
+        searchText={search}
+        onResponsableChange={setResponsable}
+        onEstadoChange={setEstado}
+        onSearchChange={setSearch}
+        onClearFilters={clearFilters}
+      />
+
+      <p>Total registros: {filtered.length}</p>
+
+      <ProcessList procesos={filtered} onSelect={setSelected} />
+      <ProcessModal proceso={selected} onClose={() => setSelected(null)} />
       <LastSyncBanner lastSync={lastSync} offline={offline} />
     </div>
   );

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+interface Props {
+  responsables: string[];
+  estados: string[];
+  selectedResponsable: string;
+  selectedEstado: string;
+  searchText: string;
+  onResponsableChange: (value: string) => void;
+  onEstadoChange: (value: string) => void;
+  onSearchChange: (value: string) => void;
+  onClearFilters: () => void;
+}
+
+export function Filters({
+  responsables,
+  estados,
+  selectedResponsable,
+  selectedEstado,
+  searchText,
+  onResponsableChange,
+  onEstadoChange,
+  onSearchChange,
+  onClearFilters,
+}: Props) {
+  return (
+    <div
+      style={{ display: "flex", gap: 8, marginBottom: 12, flexWrap: "wrap" }}
+    >
+      <select
+        value={selectedResponsable}
+        onChange={(e) => onResponsableChange(e.target.value)}
+      >
+        <option value="">(Todos)</option>
+        {responsables.map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </select>
+
+      <select
+        value={selectedEstado}
+        onChange={(e) => onEstadoChange(e.target.value)}
+      >
+        <option value="">(Todos)</option>
+        {estados.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="text"
+        placeholder="Buscar..."
+        value={searchText}
+        onChange={(e) => onSearchChange(e.target.value)}
+      />
+
+      <button type="button" onClick={onClearFilters}>
+        Limpiar filtros
+      </button>
+    </div>
+  );
+}

--- a/src/components/ProcessList.tsx
+++ b/src/components/ProcessList.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import type { Proceso } from "../types";
+
+interface Props {
+  procesos: Proceso[];
+  onSelect?: (proceso: Proceso) => void;
+}
+
+export function ProcessList({ procesos, onSelect }: Props) {
+  return (
+    <ul style={{ maxHeight: "60vh", overflowY: "auto" }}>
+      {procesos.map((p, i) => (
+        <li
+          key={i}
+          onClick={() => onSelect?.(p)}
+          style={{ cursor: onSelect ? "pointer" : "default" }}
+        >
+          <b>{p.programa}</b> — {p.estado} / {p.procedimiento} — {p.responsable}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ProcessModal.tsx
+++ b/src/components/ProcessModal.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import type { Proceso } from "../types";
+
+interface Props {
+  proceso: Proceso | null;
+  onClose: () => void;
+}
+
+export function ProcessModal({ proceso, onClose }: Props) {
+  if (!proceso) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: "rgba(0,0,0,0.3)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{ background: "#fff", padding: 16, maxWidth: 500 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2>{proceso.programa}</h2>
+        <p>
+          <b>Responsable:</b> {proceso.responsable}
+        </p>
+        <p>
+          <b>Estado:</b> {proceso.estado}
+        </p>
+        <p>{proceso.observaciones}</p>
+        <button onClick={onClose}>Cerrar</button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useProcesos.ts
+++ b/src/hooks/useProcesos.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
-import { loadProcesos, saveProcesos, Proceso } from '../lib/db';
+import { useCallback, useEffect, useState } from "react";
+import { loadProcesos, saveProcesos } from "../lib/db";
+import type { Proceso } from "../types";
 
 export function useProcesos() {
   const [data, setData] = useState<Proceso[]>([]);
@@ -13,7 +14,10 @@ export function useProcesos() {
     setError(null);
     setOffline(false);
     try {
-      const url = (import.meta.env.VITE_DATA_URL || '/procesos.json') + '?t=' + Date.now();
+      const url =
+        (import.meta.env.VITE_DATA_URL || "/procesos.json") +
+        "?t=" +
+        Date.now();
       const res = await fetch(url);
       if (!res.ok) throw new Error(res.statusText);
       const json: Proceso[] = await res.json();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,27 +1,20 @@
-import { get, set } from 'idb-keyval';
+import { get, set } from "idb-keyval";
+import type { Proceso } from "../types";
 
-export type Proceso = {
-  programa: string;
-  facultad: string;
-  rrc_raa: string;
-  procedimiento: string;
-  modalidad: string;
-  responsable: string;
-  estado: string;
-  observaciones: string;
-};
-
-const KEY_PROCESOS = 'procesos';
-const KEY_LAST_SYNC = 'lastSync';
+const KEY_PROCESOS = "procesos";
+const KEY_LAST_SYNC = "lastSync";
 
 export async function saveProcesos(data: Proceso[], date: Date) {
   await Promise.all([set(KEY_PROCESOS, data), set(KEY_LAST_SYNC, date)]);
 }
 
-export async function loadProcesos(): Promise<{ data: Proceso[]; lastSync: Date | null }> {
+export async function loadProcesos(): Promise<{
+  data: Proceso[];
+  lastSync: Date | null;
+}> {
   const [data, last] = await Promise.all([
     get<Proceso[]>(KEY_PROCESOS),
-    get<Date>(KEY_LAST_SYNC)
+    get<Date>(KEY_LAST_SYNC),
   ]);
   return { data: data || [], lastSync: last || null };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export type Proceso = {
+  programa: string;
+  facultad: string;
+  rrc_raa: string;
+  procedimiento: string;
+  modalidad: string;
+  responsable: string;
+  estado: string;
+  observaciones: string;
+};


### PR DESCRIPTION
## Summary
- manage filter state in `App`
- implement Filters component
- show list and modal components
- export Proceso type
- document filters and search

## Testing
- `npm run format`
- `npm run build`
- `npm run preview` *(terminated with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_688294277f1c8327bdd04bec567c82ce