### PR TITLE
Enable GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,22 @@
 name: Deploy
 on:
-  workflow_dispatch: {}
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:
-    if: false  # deshabilitado por defecto
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
       - run: npm ci
       - run: npm run build
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ campo de texto libre que busca coincidencias en *programa* u
 El botón **Limpiar filtros** restablece todo a `(Todos)`.
 
 ## Deploy
-Puede desplegarse en servicios como Netlify o GitHub Pages. En ambos casos,
-defina las variables del `.env` en el panel del servicio y ejecute el script
-de construcción.
+La aplicación se publica automáticamente en GitHub Pages después de cada push a
+`main`. Puede consultarse en:
 
-El workflow en `.github/workflows/deploy.yml` está deshabilitado por defecto;
-puede habilitarlo eliminando la condición `if: false`.
+<https://Wilzard95.github.io/APK-Posgrados-Controldeactividades/>
+
+Para volver a desplegar manualmente solo ejecute un push a la rama `main` o
+dispare el workflow **Deploy** desde la pestaña *Actions*. El workflow instala
+las dependencias, ejecuta `npm run build` y actualiza la rama `gh-pages` con el
+contenido de `dist/`.
 
 ## Troubleshooting
 - **No aparece la información**: verifique que el link de Excel esté correcto y

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  base: "/APK-Posgrados-Controldeactividades/",
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set Vite base path for GitHub Pages
- enable deploy workflow on push to `main`
- document public URL and how to redeploy

## Testing
- `npm ci`
- `npm run build`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68829b73e3cc83279d261dcad17de5c6