### PR TITLE
Improve list UI with grouping and export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { LastSyncBanner } from "./components/LastSyncBanner";
 import { Filters } from "./components/Filters";
 import { ProcessList } from "./components/ProcessList";
 import { ProcessModal } from "./components/ProcessModal";
+import { exportProcesosToXLSX } from "./lib/export";
 import type { Proceso } from "./types";
 
 export default function App() {
@@ -63,7 +64,15 @@ export default function App() {
         onClearFilters={clearFilters}
       />
 
-      <p>Total registros: {filtered.length}</p>
+      <p>
+        Total registros: {filtered.length}{" "}
+        <button
+          type="button"
+          onClick={() => exportProcesosToXLSX(filtered, "procesos_filtrados.xlsx")}
+        >
+          Exportar filtrado a Excel
+        </button>
+      </p>
 
       <ProcessList procesos={filtered} onSelect={setSelected} />
       <ProcessModal proceso={selected} onClose={() => setSelected(null)} />

--- a/src/components/ProcessList.tsx
+++ b/src/components/ProcessList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import type { Proceso } from "../types";
 
 interface Props {
@@ -6,18 +6,69 @@ interface Props {
   onSelect?: (proceso: Proceso) => void;
 }
 
+function getEstadoColor(estado: string) {
+  const e = estado.toLowerCase();
+  if (e.includes("completado")) return "#2ecc71"; // verde
+  if (e.includes("pendiente")) return "#f1c40f"; // amarillo
+  if (e.includes("devuelto") || e.includes("desist")) return "#e74c3c"; // rojo
+  return "#3498db"; // azul por defecto
+}
+
 export function ProcessList({ procesos, onSelect }: Props) {
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+  const groups = useMemo(() => {
+    const map = new Map<string, Proceso[]>();
+    procesos.forEach((p) => {
+      if (!map.has(p.responsable)) map.set(p.responsable, []);
+      map.get(p.responsable)!.push(p);
+    });
+    return Array.from(map.entries()).sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+  }, [procesos]);
+
+  const toggle = (r: string) =>
+    setCollapsed((c) => ({ ...c, [r]: !c[r] }));
+
   return (
-    <ul style={{ maxHeight: "60vh", overflowY: "auto" }}>
-      {procesos.map((p, i) => (
-        <li
-          key={i}
-          onClick={() => onSelect?.(p)}
-          style={{ cursor: onSelect ? "pointer" : "default" }}
-        >
-          <b>{p.programa}</b> — {p.estado} / {p.procedimiento} — {p.responsable}
-        </li>
+    <div style={{ maxHeight: "60vh", overflowY: "auto" }}>
+      {groups.map(([resp, items]) => (
+        <div key={resp} style={{ marginBottom: 8 }}>
+          <h3
+            onClick={() => toggle(resp)}
+            style={{ cursor: "pointer", userSelect: "none", margin: 0 }}
+          >
+            {collapsed[resp] ? "▶" : "▼"} {resp} ({items.length})
+          </h3>
+          {!collapsed[resp] && (
+            <ul style={{ marginTop: 4 }}>
+              {items.map((p, i) => (
+                <li
+                  key={i}
+                  onClick={() => onSelect?.(p)}
+                  style={{ cursor: onSelect ? "pointer" : "default" }}
+                >
+                  <b>{p.programa}</b> —
+                  <span
+                    style={{
+                      background: getEstadoColor(p.estado),
+                      color: "#fff",
+                      borderRadius: 4,
+                      padding: "0 4px",
+                      margin: "0 4px",
+                      fontSize: 12,
+                    }}
+                  >
+                    {p.estado}
+                  </span>
+                  / {p.procedimiento}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       ))}
-    </ul>
+    </div>
   );
 }

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,9 @@
+import { utils, writeFile, type WorkBook } from 'xlsx';
+import type { Proceso } from '../types';
+
+export function exportProcesosToXLSX(data: Proceso[], filename = 'procesos.xlsx') {
+  const ws = utils.json_to_sheet(data);
+  const wb: WorkBook = utils.book_new();
+  utils.book_append_sheet(wb, ws, 'Procesos');
+  writeFile(wb, filename);
+}


### PR DESCRIPTION
## Summary
- group processes by Responsable with collapsible sections
- add colored badges for each estado
- provide export of filtered list to Excel

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882a042ec508327af1c861b2ae2f41b