### PR TITLE
Fix Node version for deploy workflow

### DIFF
--- a/.github/workflows/convert-xlsx.yml
+++ b/.github/workflows/convert-xlsx.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - name: Obtain XLSX

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Summary
- update Node to 20 in deploy workflow
- update Node to 20 in convert-xlsx workflow

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882abcc8fc48327a228df2286554d1a