### PR TITLE
Fix deploy workflow permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow GitHub Pages deploy to generate an OIDC token by setting workflow permissions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882adac014c8327962b031006e800c2